### PR TITLE
Custom CMake for Travis-CI build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ dist: bionic
 
 language: c
 
+env:
+  global:
+    - DEPS_DIR=${TRAVIS_BUILD_DIR}/deps
+
 install:
   # Download and install recent cmake
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 script:
   - date
   - mkdir .build && cd .build && cmake ..
+  - make
   - make test
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,16 @@ dist: bionic
 
 language: c
 
+install:
+  # Download and install recent cmake
+  - |
+      if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
+        CMAKE_URL="http://www.cmake.org/files/v3.18/cmake-3.18.1-Linux-x86_64.tar.gz"
+        mkdir -p ${DEPS_DIR}/cmake
+        travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
+        export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+      fi
+
 script:
   - date
   - mkdir .build && cd .build && cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ language: c
 install:
   # Download and install recent cmake
   - |
-      if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
-        CMAKE_URL="http://www.cmake.org/files/v3.18/cmake-3.18.1-Linux-x86_64.tar.gz"
-        mkdir -p ${DEPS_DIR}/cmake
-        travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
-        export PATH=${DEPS_DIR}/cmake/bin:${PATH}
-      fi
+      CMAKE_URL="http://www.cmake.org/files/v3.18/cmake-3.18.1-Linux-x86_64.tar.gz"
+      mkdir -p ${DEPS_DIR}/cmake
+      travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
+      export PATH=${DEPS_DIR}/cmake/bin:${PATH}
 
 script:
   - date

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.18 FATAL_ERROR)
 
 # fetch external dependencies
 include(FetchContent)


### PR DESCRIPTION
Turns out that CMake that ships with Travis-CI's `bionic` dist cannot handle `FetchContent_MakeAvailable`. This function can be replaced by its body in our case, but that would be extremely painful, or so it seems to me. Let's pull a modern version of CMake instead.