### PR TITLE
WIP: init, shutdown and text document sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,11 @@ FetchContent_Declare(jsonh
 FetchContent_Declare(picohttpparser
   GIT_REPOSITORY https://github.com/h2o/picohttpparser.git
   GIT_TAG 8ba2328)
+FetchContent_Declare(librope
+  GIT_REPOSITORY https://github.com/josephg/librope.git
+  GIT_TAG 81e1938)
 
-FetchContent_MakeAvailable(jsonh picohttpparser)
+FetchContent_MakeAvailable(jsonh picohttpparser librope)
 
 project (TEST)
 
@@ -18,8 +21,17 @@ project (TEST)
 add_library(picohttpparser
   ${picohttpparser_SOURCE_DIR}/picohttpparser.c
   ${picohttpparser_SOURCE_DIR}/picohttpparser.h)
+# librope does not supply a CMakeLists.txt file,
+# so define a library yourself
+add_library(librope
+  ${librope_SOURCE_DIR}/rope.c
+  ${librope_SOURCE_DIR}/rope.h)
+target_compile_definitions(librope PUBLIC ROPE_WCHAR=1)
 
-include_directories(${jsonh_SOURCE_DIR} ${picohttpparser_SOURCE_DIR})
+include_directories(
+  ${jsonh_SOURCE_DIR}
+  ${picohttpparser_SOURCE_DIR}
+  ${librope_SOURCE_DIR})
 
 add_subdirectory (src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library (json_rpc json_rpc.c json_rpc.h)
-#add_executable (demo main.cpp)
-#target_link_libraries (demo json_rpc)
+
+add_executable (xatslsp xatslsp_main.c language_server.c)
+target_link_libraries (xatslsp json_rpc picohttpparser)

--- a/src/json_rpc.h
+++ b/src/json_rpc.h
@@ -15,10 +15,14 @@ void json_rpc_invalid_request_error(FILE *fout, json_rpc_request_notification_t 
 void json_rpc_method_not_found_error(FILE *fout, json_rpc_request_notification_t *request);
 void json_rpc_invalid_params_error(FILE *fout, json_rpc_request_notification_t *request, const char *reason);
 void json_rpc_internal_error(FILE *fout, json_rpc_request_notification_t *request, const char *reason);
+void json_rpc_custom_error(FILE *fout, json_rpc_request_notification_t *request, int error_code, const char *message);
 
+void json_rpc_custom_success(FILE *fout, json_rpc_request_notification_t *request, const char *json);
 void json_rpc_success(FILE *fout, json_rpc_request_notification_t *request, const struct json_value_s *json);
 
 int json_rpc_parse_request_notification(struct json_value_s *root, json_rpc_request_notification_t *res);
+
+int json_rpc_request_is_notification(json_rpc_request_notification_t *request);
 
 typedef
 int (*json_rpc_evaluate_t)(FILE *fout, json_rpc_request_notification_t *request, void *state);

--- a/src/xatslsp_main.c
+++ b/src/xatslsp_main.c
@@ -1,0 +1,6 @@
+#include "language_server.h"
+
+int main(int argc, char **argv) {
+  language_server_loop();
+  return 0;
+}


### PR DESCRIPTION
This PR will handle initialization, shutdown of the server and also text document sync, so we can properly maintain a "typing environment" for doing the actual compiler calls.

I decided to go with ropes because even though the text is transmitted as UTF-8, the offsets are in UTF-16 anyways, so we will need to convert back and fro.