### PR TITLE
Init, shutdown, and sync docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(librope
 
 FetchContent_MakeAvailable(jsonh picohttpparser librope)
 
-project (TEST)
+project (XATSLSP)
 
 # picohttpparser does not supply a CMakeLists.txt file,
 # so define a library yourself

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,3 +2,5 @@ add_library (json_rpc json_rpc.c json_rpc.h)
 
 add_executable (xatslsp xatslsp_main.c language_server.c)
 target_link_libraries (xatslsp json_rpc picohttpparser)
+
+install(TARGETS xatslsp DESTINATION bin)

--- a/src/json_rpc.c
+++ b/src/json_rpc.c
@@ -4,11 +4,132 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
+#include <stdarg.h>
 
 #include "picohttpparser.h"
 #include "json.h"
 
 #include "json_rpc.h"
+
+struct json_string_s json_make_string(const char *value) {
+  assert(value != NULL);
+  struct json_string_s string = {value, strlen(value)};
+  return string;
+}
+
+struct json_number_s json_make_number(const char *num) {
+  assert(num != NULL);
+  struct json_number_s number = {num, strlen(num)};
+  return number;
+}
+
+struct json_object_s json_object_empty() {
+  struct json_object_s obj = {NULL, 0};
+  return obj;
+}
+
+// NOTE: expects NULL-terminated [struct json_object_element_s *prop] arguments!
+void json_object_extend(struct json_object_s *obj, ...) {
+  assert(obj != NULL);
+
+  va_list args;
+
+  va_start(args, obj);
+  while (1) {
+    struct json_object_element_s *prop = va_arg(args, struct json_object_element_s *);
+    if (prop == NULL) {
+      break;
+    }
+    if (prop->value == NULL) {
+      continue; // skip it (if you want the null literal as property of object, use the corresponding value!)
+    }
+
+    struct json_object_element_t *tmp = obj->start;
+    obj->start = prop;
+    prop->next = tmp;
+    obj->length++;    
+  }
+  va_end(args);
+}
+
+struct json_value_s json_value_string(const struct json_string_s *str) {
+  assert(str != NULL);
+  struct json_value_s value = {str, json_type_string};
+  return value;
+}
+struct json_value_s json_value_number(const struct json_number_s *num) {
+  assert(num != NULL);
+  struct json_value_s value = {num, json_type_number};
+  return value;
+}
+struct json_value_s json_value_object(const struct json_object_s *obj) {
+  if (obj != NULL) {
+    struct json_value_s value = {obj, json_type_object};
+    return value;
+  } else {
+    struct json_value_s value = {NULL, json_type_null};
+    return value;
+  }
+}
+
+#define JSON_PROP_NUMBER(name, prop, value)                             \
+  struct json_string_s name##_prop_string = json_make_string((prop));   \
+  struct json_number_s name##_value_number = json_make_number((value)); \
+  struct json_value_s  name##_value_number_v = json_value_number(&(name##_value_number)); \
+  struct json_object_element_s name = {&(name##_prop_string), &(name##_value_number_v), NULL};
+#define JSON_PROP_STRING(name, prop, value)                           \
+  struct json_string_s name##_prop_string = json_make_string((prop));   \
+  struct json_string_s name##_value_string = json_make_string((value));      \
+  struct json_value_s  name##_value_string_v = json_value_string(&(name##_value_string)); \
+  struct json_object_element_s name = {&(name##_prop_string), &(name##_value_string_v), NULL};
+#define JSON_PROP_OBJECT(name, prop, object) \
+  struct json_string_s name##_prop_string = json_make_string((prop)); \
+  struct json_value_s name##_value_object = json_value_object(&object); \
+  struct json_object_element_s name = {&(name##_prop_string), &(name##_value_object), NULL};
+#define JSON_PROP_VALUE(name, prop, value)                            \
+  struct json_string_s name##_prop_string = json_make_string((prop));    \
+  struct json_object_element_s name = {&(name##_prop_string), (value), NULL};
+
+static void json_rpc_write_response(FILE *fout, struct json_value_s *value) {
+  if (value == NULL) {
+    fprintf(fout, "Content-Length: 4\r\n\r\nnull");
+  } else {
+    size_t size = 0;
+    char *string = json_write_minified(value, &size);
+
+    assert(string != NULL);
+    fprintf(fout, "Content-Length: %ld\r\n\r\n%s", size, string);
+
+    free(string);
+  }
+  fflush(fout);
+}
+
+static void json_rpc_error(FILE *fout, const struct json_value_s *id, const char *code, const char *message, const struct json_value_s *data) {
+  JSON_PROP_NUMBER(error_code, "code", code);
+  JSON_PROP_STRING(error_message, "message", message);
+  JSON_PROP_VALUE(error_data, "data", data);
+
+  struct json_object_s error_obj = json_object_empty();
+  json_object_extend(&error_obj, &error_data, &error_message, &error_code, NULL);
+
+  struct json_object_s response_obj = json_object_empty();
+  JSON_PROP_STRING(jsonrpc, "jsonrpc", "2.0");
+  JSON_PROP_OBJECT(error, "error", error_obj);
+
+  if (id != NULL) {
+    JSON_PROP_VALUE(id_prop, "id", id);
+    json_object_extend(&response_obj, &id_prop, &error, &jsonrpc, NULL);
+
+    struct json_value_s response = json_value_object(&response_obj);
+    json_rpc_write_response(fout, &response);
+  } else {
+    json_object_extend(&response_obj, &error, &jsonrpc, NULL);
+
+    struct json_value_s response = json_value_object(&response_obj);
+    json_rpc_write_response(fout, &response);
+  }
+}
 
 void json_rpc_parse_error(FILE *fout, struct json_value_s *id, struct json_parse_result_s *result) {
   assert(result->error != json_parse_error_none);
@@ -50,187 +171,170 @@ void json_rpc_parse_error(FILE *fout, struct json_value_s *id, struct json_parse
     reason = "unknown error";
     break;
   }
-  
-  fprintf(fout, "{\"jsonrpc\": \"2.0\", \"error\": ");
-  
-  fprintf(fout, "{\"code\": -32700, \"message\": \"Parse error\", \"data\": \"Error parsing JSON: %lu(line=%lu, offs=%lu): %s\"}",
-    result->error_offset, result->error_line_no, result->error_row_no, reason);
-  
-  if (id != NULL) {
-    char *idstring = json_write_minified(id, NULL);
-    if (idstring != NULL) {
-      fprintf(fout, ", \"id\": %s", idstring);
-      free(idstring);
-    }
+
+  char data_buf[1024];
+  data_buf[0] = 0;
+  int data_used = snprintf(data_buf, sizeof(data_buf), "Error parsing JSON: %lu(line=%lu, offs=%lu): %s",
+                           result->error_offset, result->error_line_no, result->error_row_no, reason);
+  if (!(data_used >= 0 && data_used < sizeof(data_buf)-1)) {
+    snprintf(data_buf, sizeof(data_buf), "Unable to print error location: buffer overflow!");
   }
-  
-  fprintf(fout, "}");
+
+  struct json_string_s data_string = json_make_string(data_buf);
+  struct json_value_s data = json_value_string(&data_string);
+  json_rpc_error(fout, id, "-32700", "Parse error", &data);
 }
 
 void json_rpc_invalid_request_error(FILE *fout, json_rpc_request_notification_t *request) {
-  fprintf(fout, "{\"jsonrpc\": \"2.0\", \"error\": ");
-  
-  fprintf(fout, "{\"code\": -32600, \"message\": \"Invalid request\"}");
-  
-  if (request->id != NULL) {
-    char *idstring = json_write_minified(request->id, NULL);
-    if (idstring != NULL) {
-      fprintf(fout, ", \"id\": %s", idstring);
-      free(idstring);
-    }
-  }
-  
-  fprintf(fout, "}");
+  assert(request != NULL);
+
+  json_rpc_error(fout, request->id, "-32600", "Invalid request", NULL);
 }
 
 void json_rpc_method_not_found_error(FILE *fout, json_rpc_request_notification_t *request) {
   assert(request != NULL);
 
-  fprintf(fout, "{\"jsonrpc\": \"2.0\", \"error\": ");
-  
-  const char *method = request->method->string;
-  struct json_value_s method_value = {request->method, json_type_string};
-    
-  char *method_json = json_write_minified(&method_value, NULL);
-  
-  fprintf(fout, "{\"code\": -32601, \"message\": \"Method not found\", \"data\": %s}", method_json);
-  free(method_json);
-
-  if (request->id != NULL) {
-    char *idstring = json_write_minified(request->id, NULL);
-    if (idstring != NULL) {
-      fprintf(fout, ", \"id\": %s", idstring);
-      free(idstring);
-    }
-  }
-  
-  fprintf(fout, "}");
+  struct json_value_s method_value = json_value_string(request->method);
+  json_rpc_error(fout, request->id, "-32601", "Method not found", &method_value);
 }
 
 void json_rpc_invalid_params_error(FILE *fout, json_rpc_request_notification_t *request, const char *reason) {
-  fprintf(fout, "{\"jsonrpc\": \"2.0\", \"error\": ");
-  
-  fprintf(fout, "{\"code\": -32602, \"message\": \"Invalid params\"");
+  assert(request != NULL);
 
   if (reason != NULL && strlen(reason) > 0) {
-    struct json_string_s reason_string = {reason, strlen(reason)};
-    struct json_value_s reason_value = {&reason_string, json_type_string};
+    struct json_string_s reason_string = json_make_string (reason);
+    struct json_value_s reason_value = json_value_string (&reason_string);
     
-    char *reason_json = json_write_minified(&reason_value, NULL);
-    if (reason_json != NULL) {
-      fprintf(fout, ", \"data\": %s", reason_json);
-      free(reason_json);
-    }
+    json_rpc_error(fout, request->id, "-32602", "Invalid params", &reason_value);
+  } else {
+    json_rpc_error(fout, request->id, "-32602", "Invalid params", NULL);
   }
-
-  fprintf(fout, "}");
-  
-  if (request->id != NULL) {
-    char *idstring = json_write_minified(request->id, NULL);
-    if (idstring != NULL) {
-      fprintf(fout, ", \"id\": %s", idstring);
-      free(idstring);
-    }
-  }
-  
-  fprintf(fout, "}");  
 }
 
 void json_rpc_internal_error(FILE *fout, json_rpc_request_notification_t *request, const char *reason) {
-  fprintf(fout, "{\"jsonrpc\": \"2.0\", \"error\": ");
-  
-  fprintf(fout, "{\"code\": -32603, \"message\": \"Internal error\"");
+  assert(request != NULL);
 
   if (reason != NULL && strlen(reason) > 0) {
-    struct json_string_s reason_string = {reason, strlen(reason)};
-    struct json_value_s reason_value = {&reason_string, json_type_string};
+    struct json_string_s reason_string = json_make_string (reason);
+    struct json_value_s reason_value = json_value_string (&reason_string);
     
-    char *reason_json = json_write_minified(&reason_value, NULL);
-    if (reason_json != NULL) {
-      fprintf(fout, ", \"data\": %s", reason_json);
-      free(reason_json);
-    }
+    json_rpc_error(fout, request->id, "-32603", "Internal error", &reason_value);
+  } else {
+    json_rpc_error(fout, request->id, "-32603", "Internal error", NULL);
   }
-
-  fprintf(fout, "}");  
-  
-  if (request->id != NULL) {
-    char *idstring = json_write_minified(request->id, NULL);
-    if (idstring != NULL) {
-      fprintf(fout, ", \"id\": %s", idstring);
-      free(idstring);
-    }
-  }
-  
-  fprintf(fout, "}");  
 }
 
 void json_rpc_custom_error(FILE *fout, json_rpc_request_notification_t *request, int error_code, const char *message) {
-  fprintf(fout, "{\"jsonrpc\": \"2.0\", \"error\": ");
+  assert(request != NULL);
 
-  fprintf(fout, "{\"code\": %d, \"message\": ", error_code);
+  char error_buf[16];
+  error_buf[0] = 0;
+  int error_used = snprintf(error_buf, sizeof(error_buf), "%d", error_code);
+  assert(error_used >= 0 && error_used < sizeof(error_buf)-1);
 
-  if (message != NULL && strlen(message) > 0) {
-    struct json_string_s message_string = {message, strlen(message)};
-    struct json_value_s message_value = {&message_string, json_type_string};
-
-    char *message_json = json_write_minified(&message_value, NULL);
-    if (message_json != NULL) {
-      fprintf(fout, "%s", message_json);
-      free(message_json);
-    } else {
-      fprintf(fout, "\"\"");
-    }
-  } else {
-    fprintf(fout, "\"(no message)\"");
+  if (message == NULL) {
+    message = "(no message)";
   }
 
-  fprintf(fout, "}");
-
-  if (request->id != NULL) {
-    char *idstring = json_write_minified(request->id, NULL);
-    if (idstring != NULL) {
-      fprintf(fout, ", \"id\": %s", idstring);
-      free(idstring);
-    }
-  }
-
-  fprintf(fout, "}");
+  struct json_string_s message_string = json_make_string (message);
+  struct json_value_s message_value = json_value_string (&message_string);
+    
+  json_rpc_error(fout, request->id, error_buf, message, NULL);
 }
 
 void json_rpc_custom_success(FILE *fout, json_rpc_request_notification_t *request, const char *json) {
-  fprintf(fout, "{\"jsonrpc\": \"2.0\", \"result\": ");
+  assert(request != NULL);
+  assert(json != NULL);
+  
+  struct json_parse_result_s parse_result;
+  size_t json_length = strlen(json);
+  struct json_value_s *json_value = json_parse_ex(json, json_length, json_parse_flags_default, NULL, NULL, &parse_result);
 
-  fprintf(fout, "%s", json);
-
-  if (request->id != NULL) {
-    char *idstring = json_write_minified(request->id, NULL);
-    if (idstring != NULL) {
-      fprintf(fout, ", \"id\": %s", idstring);
-      free(idstring);
+  if (parse_result.error != json_parse_error_none) {
+    const char *reason;
+    // TODO: put into a lookup array
+    switch (parse_result.error) {
+    case json_parse_error_expected_comma_or_closing_bracket:
+      reason = "expected either a comma or a closing brace or bracket to close an object or array";
+      break;
+    case json_parse_error_expected_colon:
+      reason = "colon separating name/value pair was missing";
+      break;
+    case json_parse_error_expected_opening_quote:
+      reason = "expected string to begin with a double quote";
+      break;
+    case json_parse_error_invalid_string_escape_sequence:
+      reason = "invalid escaped sequence in string";
+      break;
+    case json_parse_error_invalid_number_format:
+      reason = "invalid number format";
+      break;
+    case json_parse_error_invalid_value:
+      reason = "invalid value";
+      break;
+    case json_parse_error_premature_end_of_buffer:
+      reason = "reached end of buffer before object/array was complete";
+      break;
+    case json_parse_error_invalid_string:
+      reason = "string was malformed";
+      break;
+    case json_parse_error_allocator_failed:
+      reason = "a call to malloc, or a user provider allocator, failed.";
+      break;
+    case json_parse_error_unexpected_trailing_characters:
+      reason = "the JSON input had unexpected trailing characters that weren't part of the JSON value";
+      break;
+    case json_parse_error_unknown:
+    default:
+      reason = "unknown error";
+      break;
     }
+
+    char data_buf[1024];
+    data_buf[0] = 0;
+    int data_used = snprintf(data_buf, sizeof(data_buf), "Error parsing JSON: %lu(line=%lu, offs=%lu): %s",
+                             parse_result.error_offset, parse_result.error_line_no, parse_result.error_row_no, reason);
+    if (!(data_used >= 0 && data_used < sizeof(data_buf)-1)) {
+      snprintf(data_buf, sizeof(data_buf), "Unable to print error location: buffer overflow!");
+    }
+
+    struct json_string_s data_string = json_make_string(data_buf);
+    struct json_value_s data = json_value_string(&data_string);
+
+    json_rpc_error(fout, request->id, "-32603", "Internal error", &data);
+  } else {
+    json_rpc_success(fout, request, json_value);
   }
 
-  fprintf(fout, "}");
+  if (json_value != json_null) {
+    free(json_value);
+  }
 }
 
 void json_rpc_success(FILE *fout, json_rpc_request_notification_t *request, const struct json_value_s *result) {
-  fprintf(fout, "{\"jsonrpc\": \"2.0\", \"result\": ");
+  assert(request != NULL);
 
-  char *result_json = json_write_minified(result, NULL);
-  assert(result_json != NULL);
-  fprintf(fout, "%s", result_json);
-  free(result_json);
+  struct json_value_s null_result = {NULL, json_type_null};
+  if (result == NULL) {
+    result = &null_result;
+  }
+
+  struct json_object_s response_obj = json_object_empty();
+  JSON_PROP_STRING(jsonrpc, "jsonrpc", "2.0");
+  JSON_PROP_VALUE(result_prop, "result", result);
 
   if (request->id != NULL) {
-    char *idstring = json_write_minified(request->id, NULL);
-    if (idstring != NULL) {
-      fprintf(fout, ", \"id\": %s", idstring);
-      free(idstring);
-    }
+    JSON_PROP_VALUE(id_prop, "id", request->id);
+    json_object_extend(&response_obj, &id_prop, &result_prop, &jsonrpc, NULL);
+
+    struct json_value_s response = json_value_object(&response_obj);
+    json_rpc_write_response(fout, &response);
+  } else {
+    json_object_extend(&response_obj, &result_prop, &jsonrpc, NULL);
+
+    struct json_value_s response = json_value_object(&response_obj);
+    json_rpc_write_response(fout, &response);
   }
-  
-  fprintf(fout, "}");    
 }
 
 int json_rpc_parse_request_notification(struct json_value_s *root, json_rpc_request_notification_t *res) {
@@ -305,7 +409,7 @@ struct phr_header *get_request_header(struct phr_header *headers, size_t num_hea
 }
 
 char *parse_request(FILE *fd, struct phr_header *headers, size_t *num_headers, size_t *content_length) {
-  char buf[4096];
+  char buf[128];
   size_t buflen = 0, prevbuflen = 0;
   size_t rret;
   int pret = 0;
@@ -316,8 +420,10 @@ char *parse_request(FILE *fd, struct phr_header *headers, size_t *num_headers, s
   while (1) {
     // read the request
     rret = fread(buf + buflen, 1, sizeof(buf) - buflen, fd);
-    if (rret == 0)
+    if (rret == 0) {
+      fprintf(stderr, "parse_request: unexpected EOF on fd\n");
       return NULL; // unexpected EOF
+    }
 
     prevbuflen = buflen;
     buflen += rret;
@@ -384,7 +490,7 @@ int json_rpc_server_step(FILE *fd, FILE *fout, json_rpc_evaluate_t evaluate, voi
   char *content = parse_request(fd, headers, &num_headers, &content_length);
     
   if (content == NULL) {
-    // failed to parse anything
+    fprintf(stderr, "json_rpc_server_step: failed to parse anything\n");
     return 1;
   }
   // printf("RAW content: %s with length %d\n", content, content_length);

--- a/src/json_rpc.h
+++ b/src/json_rpc.h
@@ -1,7 +1,81 @@
 #ifndef __JSON_RPC_H__
 #define __JSON_RPC_H__
 
+#include <assert.h>
+#include <string.h>
+
 #include "json.h"
+
+/* ****** ****** */
+
+json_weak
+struct json_string_s json_make_string(const char *value) {
+  assert(value != NULL);
+  struct json_string_s string = {value, strlen(value)};
+  return string;
+}
+
+json_weak
+struct json_number_s json_make_number(const char *num) {
+  assert(num != NULL);
+  struct json_number_s number = {num, strlen(num)};
+  return number;
+}
+
+json_weak
+struct json_object_s json_object_empty() {
+  struct json_object_s obj = {NULL, 0};
+  return obj;
+}
+
+// NOTE: expects NULL-terminated [struct json_object_element_s *prop] arguments!
+// - will cons all of them onto the property list of [obj]
+void json_object_extend(struct json_object_s *obj, ...);
+
+json_weak
+struct json_value_s json_value_string(const struct json_string_s *str) {
+  assert(str != NULL);
+  struct json_value_s value = {str, json_type_string};
+  return value;
+}
+
+json_weak
+struct json_value_s json_value_number(const struct json_number_s *num) {
+  assert(num != NULL);
+  struct json_value_s value = {num, json_type_number};
+  return value;
+}
+
+json_weak
+struct json_value_s json_value_object(const struct json_object_s *obj) {
+  if (obj != NULL) {
+    struct json_value_s value = {obj, json_type_object};
+    return value;
+  } else {
+    struct json_value_s value = {NULL, json_type_null};
+    return value;
+  }
+}
+
+#define JSON_PROP_NUMBER(name, prop, value)                             \
+  struct json_string_s name##_prop_string = json_make_string((prop));   \
+  struct json_number_s name##_value_number = json_make_number((value)); \
+  struct json_value_s  name##_value_number_v = json_value_number(&(name##_value_number)); \
+  struct json_object_element_s name = {&(name##_prop_string), &(name##_value_number_v), NULL};
+#define JSON_PROP_STRING(name, prop, value)                             \
+  struct json_string_s name##_prop_string = json_make_string((prop));   \
+  struct json_string_s name##_value_string = json_make_string((value)); \
+  struct json_value_s  name##_value_string_v = json_value_string(&(name##_value_string)); \
+  struct json_object_element_s name = {&(name##_prop_string), &(name##_value_string_v), NULL};
+#define JSON_PROP_OBJECT(name, prop, object) \
+  struct json_string_s name##_prop_string = json_make_string((prop));   \
+  struct json_value_s name##_value_object = json_value_object(&object); \
+  struct json_object_element_s name = {&(name##_prop_string), &(name##_value_object), NULL};
+#define JSON_PROP_VALUE(name, prop, value)                              \
+  struct json_string_s name##_prop_string = json_make_string((prop));   \
+  struct json_object_element_s name = {&(name##_prop_string), (value), NULL};
+
+/* ****** ****** */
 
 typedef struct json_rpc_request_notification_s {
   struct json_value_s   *json_root; // the object that owns the memory

--- a/src/language_server.c
+++ b/src/language_server.c
@@ -5,88 +5,245 @@
 #include <errno.h>
 #include <unistd.h>
 
+// for "kill"
+#include <sys/types.h>
+#include <signal.h>
+// end of "kill"
+
 #include "picohttpparser.h"
 #include "json.h"
 #include "json_rpc.h"
+#include "language_server.h"
 
-typedef struct language_server_s {
-  FILE *fin;
-  FILE *fout;
-  int   initialized;
-} language_server_t;
+/* ****** ****** */
 
-int language_server_evaluate(FILE *fout, json_rpc_request_notification_t *request, void *state) {
-  assert(request != NULL);
-  const char *method = request->method->string;
-  
-  // before initialize:
-  //  - all notifications are to be dropped (no response to those at all)
-  //    - except for the exit notification
-  //  - all requests should be responded to with code:-32002 (message: anything)
-  // initialize:
-  //  - respond with InitializeResult
-  //  - during responding, may send back notifications:
-  //    window/showMessage, window/logMessage and telemetry/event as well
-  //    as the window/showMessageRequest request to the client. In case the
-  //    client sets up a progress token in the initialize params
-  //    (e.g. property workDoneToken) the server is also allowed to use that
-  //    token (and only that token) using the $/progress notification sent
-  //    from the server to the client.
-  //  - this request may only be sent once
-  /*
-  InitializeParams:
-  - "processId": number|null (ID of parent process; if that process is given and is not alive, we should exit)
-  - "rootUri": string(URI) | null
-  - "trace"?: 'off' | 'messages' | 'verbose' (if omitted, it is off by default)
-  - "workspaceFolders": should we support this?
-  response: InitializeResult:
-  "capabilities": ServerCapabilities
-  "serverInfo": {"name": string, "version": string}
-  possible errors:
-  - 1 // unknown protocol version
-  error.data:
-  - {retry:bool} // can client retry initialization?
-  
-  server capabilities:
-  {"textDocumentSync": {"openClose": true, "change": 2, "save": {"includeText": false}}}
-  */
-  // after initialize
-  // - client sends back the "initialized" notification
-  
-  if (0 && !strcmp(method, "sum")) {
+int is_process_running(int pid) {
+  int ret = kill((pid_t)pid, 0);
+  return (ret == 0);
+}
+
+/* ****** ****** */
+
+int validate_json_value_type(FILE *fout, json_rpc_request_notification_t *request, const char *jsonpath, struct json_value_s *value, int nullable, enum json_type_e type, const char *msg_okay) {
+  char message[256];
+  message[0] = 0;
+  char *format = NULL;
+
+  if (json_value_is_null(value)) {
+    if (!nullable) {
+      format = "the parameter '%s' is null but it should be %s";
+    } else {
+      return 1;
+    }
   } else {
-    json_rpc_method_not_found_error(fout, request);
-    return 1;
+    if (value->type != type) {
+      format = "the parameter '%s' is of mismatched type; should be %s";
+    } else {
+      return 1;
+    }
   }
+  
+  int message_used = snprintf(message, sizeof(message), format, jsonpath, msg_okay);
+  if (message_used >= 0 && message_used < sizeof(message)-1) {
+    json_rpc_invalid_params_error(fout, request, message);
+    return 0;
+  } else {
+    json_rpc_internal_error(fout, request, "INTERNAL ERROR! encoding error while trying to format validation message");
+    return 0;
+  }
+}
+
+static
+int server_parse_initialize_request(FILE *fout, json_rpc_request_notification_t *request, lsp_initialize_request_params_t *params) {
+  params->parent_process_id = -1;
+  params->root_uri = NULL;
+  params->trace = LT_OFF;
+
+  if (!validate_json_value_type(fout, request, "/params", request->params, 0, json_type_object, "InitializeParams")) {
+    return 0;
+  }
+
+  struct json_object_s *object = json_value_as_object(request->params);
+  assert(object != NULL);
+
+  struct json_object_element_s* property = object->start;
+  while (property != NULL) {
+    const char *property_name = property->name->string;
+    struct json_value_s* property_value = property->value;
+
+    if (!strcmp(property_name, "processId")) {
+      if (!validate_json_value_type(fout, request, "/params/processId", property_value, 1, json_type_number, "number (parent process id)")) {
+        return 0;
+      }
+      if (!json_value_is_null(property_value)) {
+        struct json_number_s *num = json_value_as_number(property_value);
+        assert(num != NULL);
+        params->parent_process_id = atoi(num->number);
+      }
+    } else if (!strcmp(property_name, "rootUri")) {
+      if (!validate_json_value_type(fout, request, "/params/rootUri", property_value, 1, json_type_string, "Document URI")) {
+        return 0;
+      }
+      if (!json_value_is_null(property_value)) {
+        struct json_string_s *string_value = json_value_as_string(property_value);
+        assert(string_value != NULL);
+        params->root_uri = string_value->string;
+      }
+    } else if (!strcmp(property_name, "trace")) {
+      if (!validate_json_value_type(fout, request, "/params/trace", property_value, 0, json_type_string, "trace level (off, messages, verbose, or unset)")) {
+        return 0;
+      }
+      struct json_string_s *string_value = json_value_as_string(property_value);
+      assert(string_value != NULL);
+      const char *str = string_value->string;
+      
+      if (!strcmp(str, "off")) {
+        params->trace = LT_OFF;
+      } else if (!strcmp(str, "messages")) {
+        params->trace = LT_MESSAGES;
+      } else if (!strcmp(str, "verbose")) {
+        params->trace = LT_VERBOSE;
+      } else {
+        json_rpc_invalid_params_error(fout, request, "trace should be one of \"off\", \"messages\", \"verbose\"");
+        return 0;
+      }
+    }
+
+    property = property->next;
+  }
+
+  return 1;
+}
+
 #if 0
-  // TODO: Here, do a method lookup
-  // - or continue to method execution:
-  //   - validate all parameters
-  //     - fail with -32602 	Invalid params 	Invalid method parameter(s).
-  //       - a method may evaluate to this error
-  //       - or it may evaluate to some other, internal error
-  //       - or it may evaluate to an actual result
-  //     - or execute the method
+static
+int server_parse_textDocument_didOpen_notification(FILE *fout, json_rpc_request_notification_t *request, lsp_didOpenTextDocument_notification_params_t *params) {
+  // {"textDocument": TextDocumentItem}
+  return 1;
+}
+
+static
+int server_parse_textDocument_didChange_notification(FILE *fout, json_rpc_request_notification_t *request, lsp_didChangeTextDocument_notification_params_t *params) {
   /*
-  methods we want? this depends on the actual application, so it's probably best to make this configurable.
-  */
-  printf("pretty value:\n");
-  size_t size = 0;
-  char *pretty = json_write_pretty(json_value, 0, 0, &size);
-          if (pretty != NULL) {
-            printf("%s\n", pretty);
-            free(pretty);
-          }
+{
+    textDocument: VersionedTextDocumentIdentifier;
+    contentChanges: TextDocumentContentChangeEvent[];
+}
+   */
+    /*
+      TextDocumentContentChangeEvent =
+ { // replacement
+"range": Range,
+"text": string
+}
+|
+{ // append
+"text": string
+}
+     */
+  return 1;
+}
+
+static
+int server_parse_textDocument_didClose_notification(FILE *fout, json_rpc_request_notification_t *request, lsp_didCloseTextDocument_notification_params_t *params) {
+  // {"textDocument": TextDocumentIdentifier}
+  return 1;
+}
 #endif
+
+/* ****** ****** */
+
+void server_exit(language_server_t *server) {
+  int retcode = server->shutdown_requested? 0 : 1;
+  exit(retcode);  
+}
+
+void server_initialize(language_server_t *server, json_rpc_request_notification_t *request) {
+  if (server->initialized) {
+    json_rpc_invalid_params_error(server->fout, request, "Server already initialized");
+    return;
+  }
+
+  lsp_initialize_request_params_t params;
+  memset(&params, 0, sizeof(params));
+
+  if (!server_parse_initialize_request(server->fout, request, &params)) {
+    return;
+  }
+
+  if (params.parent_process_id > 0) {
+    int parent_running = is_process_running(params.parent_process_id);
+    if (!parent_running) {
+      server_exit(server);
+    }
+  }
+  server->initialized = 1;
+
+  // NOTE:
+  // - "openClose": true means that both document open and document sent notifications are sent by the client
+  // - "change": 2 means that docs are synced by sending the full content on open; after that only incremental updates are sent by the client
+  json_rpc_custom_success(server->fout, request, "{\"capabilities\": {\"textDocumentSync\": {\"openClose\": true, \"change\": 2, \"save\": {\"includeText\": false}}},\
+\"serverInfo\": {\"name\": \"xatslsp\", \"version\": \"0.1\"}}");
+}
+
+void server_shutdown(language_server_t *server, json_rpc_request_notification_t *request) {
+  if (!server->initialized) {
+    json_rpc_invalid_params_error(server->fout, request, "Server already uninitialized");
+  }
+  // TODO: free everything, etc.
+  server->shutdown_requested = 1;
+
+  json_rpc_success(server->fout, request, json_null);
+}
+
+/* ****** ****** */
+
+void language_server_evaluate(language_server_t *server, json_rpc_request_notification_t *request) {
+  assert(request != NULL);
+  assert(server != NULL);
+
+  const char *method = request->method->string;
+
+  fprintf(stderr, "got method: %s\n", method);
+
+  if (json_rpc_request_is_notification(request)) {
+    // json_rpc_method_not_found_error(fout, request);
+    // "textDocument/didOpen"
+    // "textDocument/didChange"
+    // "textDocument/didClose"
+    if (!strcmp(method, "exit")) {
+      server_exit(server);
+    } else {
+      fprintf(stderr, "skipping it\n");
+    }
+  } else {
+    if (!strcmp(method, "initialize")) {
+      fprintf(stderr, "initialize request\n");
+      server_initialize(server, request);
+    } else if (!strcmp(method, "shutdown")) {
+      fprintf(stderr, "shutdown request\n");
+      server_shutdown(server, request);
+    } else {
+      json_rpc_method_not_found_error(server->fout, request);
+    }
+  }
+}
+
+int language_server_json_rpc_evaluate(FILE *fout, json_rpc_request_notification_t *request, void *state) {
+  assert(state != NULL);
+  language_server_t *server = (language_server_t *)state;
+
+  language_server_evaluate(server, request);
+  return 1;
 }
 
 void language_server_loop() {
-  FILE *fd = freopen(NULL, "rb", stdin); // ensure it is in binary mode (we will handle newlines)
-  FILE *fout = stderr; // should actually be stdout
-  language_server_t server = {.fin = fd, .fout = fout, .initialized = 0};
+  FILE *fd = stdin;
+  FILE *fout = stdout;
+  language_server_t server = {.fin = fd, .fout = fout, .initialized = 0, .shutdown_requested = 0};
 
-  while (1) { 
-    int cont = json_rpc_server_step(fd, fout, &language_server_evaluate, &server);
+  while (1) {
+    int cont = json_rpc_server_step(fd, fout, &language_server_json_rpc_evaluate, &server);
     if (!cont) {
       break;
     }

--- a/src/language_server.h
+++ b/src/language_server.h
@@ -8,9 +8,66 @@ typedef struct language_server_s {
   FILE *fin;
   FILE *fout;
   int   initialized;
+  int   shutdown_requested;
 } language_server_t;
 
-int language_server_evaluate(language_server_t *ls, json_rpc_request_notification_t *request);
+typedef enum {
+  LT_OFF,
+  LT_MESSAGES,
+  LT_VERBOSE
+} lsp_trace_t;
+
+typedef struct lsp_initialize_request_params_s {
+  int parent_process_id; // negative if unset
+  char *root_uri;
+  lsp_trace_t trace;
+} lsp_initialize_request_params_t;
+
+typedef struct lsp_position_s {
+  int line; // line position in a document, 0-based
+  int character; // character offset on a line in a document, 0-based
+} lsp_position_t;
+
+// this represents a selected porition of the document,
+// i.e. a set such that for any position P in the set, P >= start && P < end
+typedef struct lsp_range_s {
+  lsp_position_t start;
+  lsp_position_t end; // exclusive!
+} lsp_range_t;
+
+// this represents a location inside a resource
+typedef struct lsp_location_s {
+  char *uri;
+  lsp_range_t range;
+} lsp_location_t;
+
+// this represents a textual edit applicable to a document
+typedef struct lsp_text_edit_s {
+  lsp_range_t range; // the range to delete (to only insert, supply an empty range, i.e. start == end)
+  char *new_text; // the text to insert after range
+} lsp_text_edit_t;
+
+typedef struct lsp_versioned_document_id_s {
+  char *uri;
+  int version;
+} lsp_versioned_document_id_t;
+
+// ONLY used in DidOpenTextDocumentParams
+typedef struct lsp_text_document_item_s {
+  lsp_versioned_document_id_t id;
+  char *language_id;
+  char *text;
+} lsp_text_document_item_t;
+
+typedef struct lsp_text_document_change_s {
+  lsp_versioned_document_id_t   id;
+  int                           numChanges;
+  lsp_text_edit_t              *changes;
+} lsp_text_document_change_t;
+
+void server_exit(language_server_t *server);
+
+void language_server_evaluate(language_server_t *ls, json_rpc_request_notification_t *request);
 void language_server_loop();
 
 #endif /* !__LANGUAGE_SERVER_H__ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories (${TEST_SOURCE_DIR}/src)
 
 add_executable (json_rpc_tests json_rpc_tests.c)
 target_link_libraries (json_rpc_tests
+  PRIVATE
   json_rpc
   picohttpparser
   )

--- a/tests/json_rpc_tests.c
+++ b/tests/json_rpc_tests.c
@@ -127,43 +127,50 @@ int main(int argc, char **argv) {
 
   check_request("Empty request",
                 "Content-Length: 2\r\n\r\n{}",
-                "{\"jsonrpc\": \"2.0\", \"error\": \
-{\"code\": -32600, \"message\": \"Invalid request\"}}");
+                "Content-Length: 70\r\n\r\n\
+{\"jsonrpc\":\"2.0\",\"error\":\
+{\"code\":-32600,\"message\":\"Invalid request\"}}");
   
   check_request("Malformed request",
                 "Content-Length: 5\r\n\r\n{\"foo",
-                "{\"jsonrpc\": \"2.0\", \"error\": \
-{\"code\": -32700, \"message\": \"Parse error\", \"data\": \
+                "Content-Length: 159\r\n\r\n\
+{\"jsonrpc\":\"2.0\",\"error\":\
+{\"code\":-32700,\"message\":\"Parse error\",\"data\":\
 \"Error parsing JSON: 6(line=1, offs=6): colon separating name/value pair was missing\"}}");
 
   check_request("Unknown method",
                 "Content-Length: 61\r\n\r\n\
 {\"jsonrpc\": \"2.0\", \"method\": \"sum\", \"params\": [1,2], \"id\": 1}",
-                "{\"jsonrpc\": \"2.0\", \"error\": \
-{\"code\": -32601, \"message\": \"Method not found\", \"data\": \"sum\"}, \"id\": 1}");
+                "Content-Length: 91\r\n\r\n\
+{\"jsonrpc\":\"2.0\",\"error\":\
+{\"code\":-32601,\"message\":\"Method not found\",\"data\":\"sum\"},\"id\":1}");
 
   check_request("Internal error",
                 "Content-Length: 49\r\n\r\n\
 {\"jsonrpc\": \"2.0\", \"method\": \"interror\", \"id\": 1}",
-                "{\"jsonrpc\": \"2.0\", \"error\": \
-{\"code\": -32603, \"message\": \"Internal error\", \"data\": \"INTERNAL ERROR! Sorry, details unavailable.\\nPlease try again later\"}, \"id\": 1}");
+                "Content-Length: 153\r\n\r\n\
+{\"jsonrpc\":\"2.0\",\"error\":\
+{\"code\":-32603,\"message\":\"Internal error\",\"data\":\"INTERNAL ERROR! Sorry, details unavailable.\\nPlease try again later\"},\"id\":1}");
 
   check_request("Escaping of errors",
                 "Content-Length: 50\r\n\r\n\
 {\"jsonrpc\": \"2.0\", \"method\": \"interror2\", \"id\": 1}",
-                "{\"jsonrpc\": \"2.0\", \"error\": \
-{\"code\": -32603, \"message\": \"Internal error\", \"data\": \"INTERNAL ERROR! \\\" \"}, \"id\": 1}");
+                "Content-Length: 105\r\n\r\n\
+{\"jsonrpc\":\"2.0\",\"error\":\
+{\"code\":-32603,\"message\":\"Internal error\",\"data\":\"INTERNAL ERROR! \\\" \"},\"id\":1}");
   
 
   check_request("Invalid parameters",
                 "Content-Length: 62\r\n\r\n\
 {\"jsonrpc\": \"2.0\", \"method\": \"sum1\", \"params\": [3,2], \"id\": 1}",
-                "{\"jsonrpc\": \"2.0\", \"error\": \
-{\"code\": -32602, \"message\": \"Invalid params\", \"data\": \"there must be 2 numbers in an array, the first number being 1\"}, \"id\": 1}");
+                "Content-Length: 147\r\n\r\n\
+{\"jsonrpc\":\"2.0\",\"error\":\
+{\"code\":-32602,\"message\":\"Invalid params\",\"data\":\"there must be 2 numbers in an array, the first number being 1\"},\"id\":1}");
 
   check_request("Succesful call",
                 "Content-Length: 64\r\n\r\n\
 {\"jsonrpc\": \"2.0\", \"method\": \"sum1\", \"params\": [1,4], \"id\": \"a\"}",
-                "{\"jsonrpc\": \"2.0\", \"result\": 5.000000, \"id\": \"a\"}");
+                "Content-Length: 45\r\n\r\n\
+{\"jsonrpc\":\"2.0\",\"result\":5.000000,\"id\":\"a\"}");
 
 }


### PR DESCRIPTION
After this is done, we'll have a generic LSP server that can initialize, shutdown, exit, and sync opened docs.

- [x] `init`, `shutdown` and `exit`
- [x] `xatslsp` can be installed via `make install` target (after generating the makefile using CMake)
- [ ] document sync
- [ ] manual integration testing with (emacs-lsp)[https://github.com/emacs-lsp/lsp-mode]